### PR TITLE
versionデフォルト値を変更し、sub filterを利用できるようにした

### DIFF
--- a/scripts/build_nginx
+++ b/scripts/build_nginx
@@ -9,7 +9,7 @@ set -o pipefail
 # fail harder
 set -eu
 
-NGINX_VERSION=${NGINX_VERSION-1.26.2}
+NGINX_VERSION=${NGINX_VERSION-1.9.4}
 HEADERS_MORE_VERSION=${HEADERS_MORE_VERSION-0.37}
 UUID4_VERSION=${UUID4_VERSION-f8f7ff44e6a8c6cf75232ae4b63d011f2f3b34c1}
 
@@ -36,6 +36,7 @@ configure_opts=(
   --with-http_gzip_static_module
   --with-http_realip_module
   --with-http_ssl_module
+  --with-http_sub_module
   --add-module="${temp_dir}/nginx-${NGINX_VERSION}/headers-more-nginx-module-${HEADERS_MORE_VERSION}"
   --add-module="${temp_dir}/nginx-${NGINX_VERSION}/nginx-uuid4-module-${UUID4_VERSION}"
 )


### PR DESCRIPTION
This pull request includes changes to the `scripts/build_nginx` file to update the NGINX version and add a new module. The most important changes are:

* Updated the default `NGINX_VERSION` from `1.26.2` to `1.9.4`.
* Added the `--with-http_sub_module` to the `configure_opts` array to include the HTTP Substitution Module.